### PR TITLE
Convert reset gates of qiskit circuits

### DIFF
--- a/qat/interop/qiskit/converters.py
+++ b/qat/interop/qiskit/converters.py
@@ -417,6 +417,9 @@ def qiskit_to_qlm(qiskit_circuit, sep_measures=False, **kwargs):
             else:
                 prog.measure([qbits[i] for i in qbit_args],
                              [cbits[i] for i in cbit_args])
+        elif gate_op[0].name == "reset":
+            prog.reset([qbits[i] for i in qbit_args],
+                       [cbits[i] for i in cbit_args])
         else:
             if gate_op[0].name == "ms":
                 # In this case, the process function needs the number of qubits


### PR DESCRIPTION
Reset instructions are causing crashes when converting qiskit circuits to QLM circuits